### PR TITLE
Fix: incorrect list truncation in fast mode when comma is not followed by space

### DIFF
--- a/src/partial_json_parser/core/myelin.py
+++ b/src/partial_json_parser/core/myelin.py
@@ -120,7 +120,7 @@ def fix_fast(json_string: str, allow_partial: Union[Allow, int] = ALL):
             # { "k
             return json_string[: stack[-1][0] + 1], join_closing_tokens(stack)
 
-        last_comma = json_string.rfind(",", max(stack[-1][0], last_string_end) + 1, last_string_start - 1)
+        last_comma = json_string.rfind(",", max(stack[-1][0], last_string_end) + 1, last_string_start)
         if last_comma != -1:
             # { "key": "v", "k
             # { "key": 123, "k


### PR DESCRIPTION
Fixes an edge case in `loads(..., ALL & ~STR, )` where an unterminated string inside a list caused early truncation if commas were used without a space after.
The issue was from an off by one error in the upper bound of `rfind()` which excluded the last string element unless a space followed the comma.

Before:
`loads('{"key": ["a", "b", "c","d', ALL & ~STR)` -> `{"key": ["a", "b"]}`

After:
`loads('{"key": ["a", "b", "c", "d', ALL & ~STR)` -> `{"key": ["a", "b", "c", "d"]}`

This change adjusts the search range in `rfind()` to correctly detect the last comma, even when it is not followed by a whitespace.

This issue does not appear when using `use_fast_fix=False`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy when parsing JSON segments by refining how the last comma is detected, ensuring more reliable handling of certain JSON inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->