### PR TITLE
[chore] tag releases automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,5 @@
 name: publish
 
-# Note: this workflow evaluates Python code from this repository.
-# It therefore must not be run on untrusted input (e.g. on pull requests).
-# But that's fine, because we only want to publish when the default branch
-# is pushed to (or when a maintainer manually runs this workflow) anyways.
 on: 
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,15 +41,9 @@ jobs:
         run: |
           python src/overrides.py 3.6
           uv build
-      - name: Read version number
-        id: read-version
+      - name: Create GitHub release
         run: |
           VERSION="$(grep -m1 -oP '^__version__\s*=\s*"\K[^"]+' src/partial_json_parser/version.py)"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-      - name: Publish GitHub release
-        env:
-          VERSION: ${{ steps.read-version.outputs.VERSION }}
-        run: |
           gh release create v$VERSION --title=v$VERSION --generate-notes dist/*
       - name: Publish to PyPI
         if: ${{ github.repository == 'promplate/partial-json-parser' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,4 @@ jobs:
         env:
           VERSION: ${{ steps.read-version.outputs.VERSION }}
         run: |
-          gh release create "v$VERSION" \
-            --title="v$VERSION" \
-            --generate-notes \
-            dist/*
+          gh release create v$VERSION --title=v$VERSION --generate-notes dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: publish
 
-on: 
+on:
   push:
     branches:
       - main
@@ -59,4 +59,3 @@ jobs:
             --title="${VERSION#v}" \
             --generate-notes \
             dist/*
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,14 @@
 name: publish
 
-on: [push, workflow_dispatch]
+# Note: this workflow evaluates Python code from this repository.
+# It therefore must not be run on untrusted input (e.g. on pull requests).
+# But that's fine, because we only want to publish when the default branch
+# is pushed to (or when a maintainer manually runs this workflow) anyways.
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   diff:
@@ -25,6 +33,7 @@ jobs:
     environment: release
     if: needs.diff.outputs.CHANGED == 'true'
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -37,5 +46,21 @@ jobs:
           python src/overrides.py 3.6
           uv build
       - name: Publish to PyPI
-        continue-on-error: true
+        if: env.GITHUB_REPOSITORY == 'promplate/partial-json-parser'
         run: uv publish
+      - name: Read version number
+        id: read-version
+        run: |
+          VERSION="$(grep -m1 -oP '^__version__\s*=\s*"\K[^"]+' src/partial_json_parser/version.py)"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.read-version.outputs.VERSION }}
+        run: |
+          gh release create "v$VERSION" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="${VERSION#v}" \
+            --generate-notes \
+            dist/*
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,9 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Publish GitHub release
         env:
-          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.read-version.outputs.VERSION }}
         run: |
           gh release create "v$VERSION" \
-            --repo="$GITHUB_REPOSITORY" \
-            --title="${VERSION#v}" \
+            --title="v$VERSION" \
             --generate-notes \
             dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           python src/overrides.py 3.6
           uv build
       - name: Publish to PyPI
-        if: env.GITHUB_REPOSITORY == 'promplate/partial-json-parser'
+        if: ${{ github.repository == 'promplate/partial-json-parser' }}
         run: uv publish
       - name: Read version number
         id: read-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,6 @@ jobs:
         run: |
           python src/overrides.py 3.6
           uv build
-      - name: Publish to PyPI
-        if: ${{ github.repository == 'promplate/partial-json-parser' }}
-        run: uv publish
       - name: Read version number
         id: read-version
         run: |
@@ -54,3 +51,6 @@ jobs:
           VERSION: ${{ steps.read-version.outputs.VERSION }}
         run: |
           gh release create v$VERSION --title=v$VERSION --generate-notes dist/*
+      - name: Publish to PyPI
+        if: ${{ github.repository == 'promplate/partial-json-parser' }}
+        run: uv publish


### PR DESCRIPTION
This makes things easier for packagers :).

I did assume that you only want to publish by default when pushing to the default branch (now `main`). You can still trigger publishing from another branch by running the workflow manually. If I'm wrong, let me know and I'd be happy to change it back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined automated release pipeline to run on the main branch and via manual dispatch.
  * Added write permission for repository contents during the publish job.
  * Made publishing conditional so package publish only proceeds for the intended repository.
  * Added steps to extract the package version and create a GitHub release using that version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->